### PR TITLE
Fix continuous headings stick together

### DIFF
--- a/Syntaxes/Org.YAML-tmLanguage
+++ b/Syntaxes/Org.YAML-tmLanguage
@@ -109,6 +109,17 @@ patterns:
     '1': {name: keyword.control.block.orgmode}
   patterns:
   - include: source.lisp
+- name: meta.block.source.shell.orgmode
+  begin: '(?i)#\+(BEGIN_SRC)\s+(sh)\s*(.*)$'
+  end: '(?i)#\+(END_SRC)$'
+  beginCaptures:
+    '1': {name: keyword.control.block.orgmode}
+    '2': {name: constant.other.language.orgmode}
+    '3': {name: string.other.header-args.orgmode}
+  endCaptures:
+    '1': {name: keyword.control.block.orgmode}
+  patterns:
+  - include: source.shell
 - name: meta.block.source.other.orgmode
   contentName: markup.raw.block.orgmode
   begin: '(?i)#\+(BEGIN_(SRC|EXAMPLE))(?:\s+([\w-]+)?\s*(.*))?$'

--- a/Syntaxes/Org.YAML-tmLanguage
+++ b/Syntaxes/Org.YAML-tmLanguage
@@ -10,7 +10,7 @@ patterns:
   name: markup.heading.orgmode
   contentName: entity.name.section.orgmode
   begin: '^(\*+)\s*([A-Z_]{2,})?\s+'
-  end: '\s*$\n?'
+  end: '(?=\s*$\n?)'
   beginCaptures:
     '1': {name: punctuation.definition.heading.orgmode}
     '2': {name: keyword.other.todo.orgmode}

--- a/Syntaxes/Org.YAML-tmLanguage
+++ b/Syntaxes/Org.YAML-tmLanguage
@@ -9,7 +9,7 @@ patterns:
 - comment: Outline headings
   name: markup.heading.orgmode
   contentName: entity.name.section.orgmode
-  begin: '^(\*+)\s*([A-Z_]{2,})?\s+'
+  begin: '^(\*+)\s*([A-Z_]{2,})?\s*(?=\s+[A-Za-z]+)'
   end: '(?=\s*$\n?)'
   beginCaptures:
     '1': {name: punctuation.definition.heading.orgmode}

--- a/Syntaxes/Org.YAML-tmLanguage
+++ b/Syntaxes/Org.YAML-tmLanguage
@@ -34,10 +34,10 @@ patterns:
   patterns:
   - include: '#list-inline'
 - name: markup.quote.orgmode
-  begin: '^#\+(BEGIN_(QUOTE|VERSE|CENTER))$'
+  begin: '(?i)^#\+(BEGIN_(QUOTE|VERSE|CENTER))$'
   beginCaptures:
     '1': {name: keyword.control.block.orgmode}
-  end: '^#\+(END_\2)$'
+  end: '(?i)^#\+(END_\2)$'
   endCaptures:
     '1': {name: keyword.control.block.orgmode}
 - name: comment.line.number-sign.orgmode
@@ -59,8 +59,8 @@ patterns:
   endCaptures:
     '1': {name: keyword.control.drawer.orgmode}
 - name: meta.block.latex.orgmode
-  begin: '#\+(BEGIN_LaTeX)$'
-  end: '#\+(END_LaTeX)$'
+  begin: '(?i)#\+(BEGIN_LaTeX)$'
+  end: '(?i)#\+(END_LaTeX)$'
   beginCaptures:
     '1': {name: keyword.control.block.orgmode}
   endCaptures:
@@ -68,8 +68,8 @@ patterns:
   patterns:
   - include: text.tex.latex
 - name: meta.block.html.orgmode
-  begin: '#\+(BEGIN_HTML)$'
-  end: '#\+(END_HTML)$'
+  begin: '(?i)#\+(BEGIN_HTML)$'
+  end: '(?i)#\+(END_HTML)$'
   beginCaptures:
     '1': {name: keyword.control.block.orgmode}
   endCaptures:
@@ -77,8 +77,8 @@ patterns:
   patterns:
   - include: text.html.basic
 - name: meta.block.source.python.orgmode
-  begin: '#\+(BEGIN_SRC)\s+(python)\s*(.*)$'
-  end: '#\+(END_SRC)$'
+  begin: '(?i)#\+(BEGIN_SRC)\s+(python)\s*(.*)$'
+  end: '(?i)#\+(END_SRC)$'
   beginCaptures:
     '1': {name: keyword.control.block.orgmode}
     '2': {name: constant.other.language.orgmode}
@@ -88,8 +88,8 @@ patterns:
   patterns:
   - include: source.python
 - name: meta.block.source.ruby.orgmode
-  begin: '#\+(BEGIN_SRC)\s+(ruby)\s*(.*)$'
-  end: '#\+(END_SRC)$'
+  begin: '(?i)#\+(BEGIN_SRC)\s+(ruby)\s*(.*)$'
+  end: '(?i)#\+(END_SRC)$'
   beginCaptures:
     '1': {name: keyword.control.block.orgmode}
     '2': {name: constant.other.language.orgmode}
@@ -99,8 +99,8 @@ patterns:
   patterns:
   - include: source.ruby
 - name: meta.block.source.lisp.orgmode
-  begin: '#\+(BEGIN_SRC)\s+((?:emacs-)?lisp)\s*(.*)$'
-  end: '#\+(END_SRC)$'
+  begin: '(?i)#\+(BEGIN_SRC)\s+((?:emacs-)?lisp)\s*(.*)$'
+  end: '(?i)#\+(END_SRC)$'
   beginCaptures:
     '1': {name: keyword.control.block.orgmode}
     '2': {name: constant.other.language.orgmode}
@@ -111,8 +111,8 @@ patterns:
   - include: source.lisp
 - name: meta.block.source.other.orgmode
   contentName: markup.raw.block.orgmode
-  begin: '#\+(BEGIN_(SRC|EXAMPLE))(?:\s+([\w-]+)?\s*(.*))?$'
-  end: '#\+(END_\2)$'
+  begin: '(?i)#\+(BEGIN_(SRC|EXAMPLE))(?:\s+([\w-]+)?\s*(.*))?$'
+  end: '(?i)#\+(END_\2)$'
   beginCaptures:
     '1': {name: keyword.control.block.orgmode}
     '3': {name: constant.other.language.orgmode}

--- a/Syntaxes/Org.YAML-tmLanguage
+++ b/Syntaxes/Org.YAML-tmLanguage
@@ -9,11 +9,17 @@ patterns:
 - comment: Outline headings
   name: markup.heading.orgmode
   contentName: entity.name.section.orgmode
-  begin: '^(\*+)\s*([A-Z_]{2,})?\s*(?=\s+[A-Za-z]+)'
+  begin: |
+    (?x)
+    ^(\*+)               # leading stars
+    \s*([A-Z_]{2,})?     # todo keywords
+    \s*(\[\#[A-Ca-c]\])? # priority
+    \s*(?=\s+[A-Za-z]+)  # expected heading text
   end: '(?=\s*$\n?)'
   beginCaptures:
     '1': {name: punctuation.definition.heading.orgmode}
     '2': {name: keyword.other.todo.orgmode}
+    '3': {name: constant.other.priority.orgmode}
   patterns:
   - include: '#heading-inline'
 - name: meta.separator.orgmode

--- a/Syntaxes/Org.tmLanguage
+++ b/Syntaxes/Org.tmLanguage
@@ -13,7 +13,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>^(\*+)\s*([A-Z_]{2,})?\s+</string>
+			<string>^(\*+)\s*([A-Z_]{2,})?\s*(?=\s+[A-Za-z]+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/Syntaxes/Org.tmLanguage
+++ b/Syntaxes/Org.tmLanguage
@@ -372,6 +372,47 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>(?i)#\+(BEGIN_SRC)\s+(sh)\s*(.*)$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.block.orgmode</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.other.language.orgmode</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>string.other.header-args.orgmode</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?i)#\+(END_SRC)$</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.block.orgmode</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.block.source.shell.orgmode</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.shell</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>(?i)#\+(BEGIN_(SRC|EXAMPLE))(?:\s+([\w-]+)?\s*(.*))?$</string>
 			<key>beginCaptures</key>
 			<dict>

--- a/Syntaxes/Org.tmLanguage
+++ b/Syntaxes/Org.tmLanguage
@@ -102,7 +102,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^#\+(BEGIN_(QUOTE|VERSE|CENTER))$</string>
+			<string>(?i)^#\+(BEGIN_(QUOTE|VERSE|CENTER))$</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -112,7 +112,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>^#\+(END_\2)$</string>
+			<string>(?i)^#\+(END_\2)$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -187,7 +187,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>#\+(BEGIN_LaTeX)$</string>
+			<string>(?i)#\+(BEGIN_LaTeX)$</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -197,7 +197,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>#\+(END_LaTeX)$</string>
+			<string>(?i)#\+(END_LaTeX)$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -218,7 +218,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>#\+(BEGIN_HTML)$</string>
+			<string>(?i)#\+(BEGIN_HTML)$</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -228,7 +228,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>#\+(END_HTML)$</string>
+			<string>(?i)#\+(END_HTML)$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -249,7 +249,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>#\+(BEGIN_SRC)\s+(python)\s*(.*)$</string>
+			<string>(?i)#\+(BEGIN_SRC)\s+(python)\s*(.*)$</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -269,7 +269,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>#\+(END_SRC)$</string>
+			<string>(?i)#\+(END_SRC)$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -290,7 +290,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>#\+(BEGIN_SRC)\s+(ruby)\s*(.*)$</string>
+			<string>(?i)#\+(BEGIN_SRC)\s+(ruby)\s*(.*)$</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -310,7 +310,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>#\+(END_SRC)$</string>
+			<string>(?i)#\+(END_SRC)$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -331,7 +331,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>#\+(BEGIN_SRC)\s+((?:emacs-)?lisp)\s*(.*)$</string>
+			<string>(?i)#\+(BEGIN_SRC)\s+((?:emacs-)?lisp)\s*(.*)$</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -351,7 +351,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>#\+(END_SRC)$</string>
+			<string>(?i)#\+(END_SRC)$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -372,7 +372,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>#\+(BEGIN_(SRC|EXAMPLE))(?:\s+([\w-]+)?\s*(.*))?$</string>
+			<string>(?i)#\+(BEGIN_(SRC|EXAMPLE))(?:\s+([\w-]+)?\s*(.*))?$</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -394,7 +394,7 @@
 			<key>contentName</key>
 			<string>markup.raw.block.orgmode</string>
 			<key>end</key>
-			<string>#\+(END_\2)$</string>
+			<string>(?i)#\+(END_\2)$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>

--- a/Syntaxes/Org.tmLanguage
+++ b/Syntaxes/Org.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
@@ -32,7 +32,7 @@
 			<key>contentName</key>
 			<string>entity.name.section.orgmode</string>
 			<key>end</key>
-			<string>\s*$\n?</string>
+			<string>(?=\s*$\n?)</string>
 			<key>name</key>
 			<string>markup.heading.orgmode</string>
 			<key>patterns</key>

--- a/Syntaxes/Org.tmLanguage
+++ b/Syntaxes/Org.tmLanguage
@@ -13,7 +13,12 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>^(\*+)\s*([A-Z_]{2,})?\s*(?=\s+[A-Za-z]+)</string>
+			<string>(?x)
+^(\*+)               # leading stars
+\s*([A-Z_]{2,})?     # todo keywords
+\s*(\[\#[A-Ca-c]\])? # priority
+\s*(?=\s+[A-Za-z]+)  # expected heading text
+</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -25,6 +30,11 @@
 				<dict>
 					<key>name</key>
 					<string>keyword.other.todo.orgmode</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.other.priority.orgmode</string>
 				</dict>
 			</dict>
 			<key>comment</key>


### PR DESCRIPTION
When two heading matches are next together (i.e. no content between
them):

   HEADING_MATCH_1<NOTHING>HEADING_MATCH_2

they get merges into one. This splits the two headings by exclude
the `end' part from matching regex.

https://www.dropbox.com/s/jdhqhvr53mwlclr/Screenshot%202015-06-24%2019.55.15.png?dl=0
