### PR TITLE
Fix two orgmode parsing bugs

### DIFF
--- a/Syntaxes/Org.tmLanguage
+++ b/Syntaxes/Org.tmLanguage
@@ -581,7 +581,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>:([^:]*)(?=:)</string>
+					<string>:([^:^\s]*)(?=:)</string>
 					<key>name</key>
 					<string>meta.keyword.orgmode</string>
 				</dict>

--- a/Syntaxes/Org.tmLanguage
+++ b/Syntaxes/Org.tmLanguage
@@ -17,7 +17,7 @@
 ^(\*+)               # leading stars
 \s*([A-Z_]{2,})?     # todo keywords
 \s*(\[\#[A-Ca-c]\])? # priority
-\s*(?=\s+[A-Za-z]+)  # expected heading text
+\s*(?=\s+[A-Za-z0-9]+)  # expected heading text
 </string>
 			<key>beginCaptures</key>
 			<dict>


### PR DESCRIPTION
This takes care of two bugs:

- `* 2019`, a commonly found heading when using datetree headings in Emacs orgmode, would not be parsed as a heading, as the regular expression did not accept any digits.
- `* First part: second part time:stamp` - "second part" would be parsed as a tag. Fixed by only accepting as keyword / tag if no spaces adjacent to `:`, the same as Emacs orgmode.
